### PR TITLE
Bug Fix: Repeated Instantiations of Contract Should Overwrite Addresses

### DIFF
--- a/src/utils/setup/astroport.rs
+++ b/src/utils/setup/astroport.rs
@@ -246,9 +246,7 @@ impl TestContext {
 
         neutron
             .contract_addrs
-            .entry(TOKEN_REGISTRY_NAME.to_owned())
-            .or_default()
-            .push(addr.clone());
+            .insert(TOKEN_REGISTRY_NAME.to_owned(), addr.clone());
 
         self.astroport_token_registry = Some(DeployedContractInfo {
             code_id,
@@ -305,13 +303,11 @@ impl TestContext {
                     "contract_codes::astroport_whitelist",
                 )))?;
 
-        let native_registry_addr = neutron
-            .contract_addrs
-            .get(TOKEN_REGISTRY_NAME)
-            .and_then(|maybe_addr| maybe_addr.first())
-            .ok_or(Error::MissingContextVariable(String::from(
+        let native_registry_addr = neutron.contract_addrs.get(TOKEN_REGISTRY_NAME).ok_or(
+            Error::MissingContextVariable(String::from(
                 "contract_ddrs::astroport_native_coin_registry",
-            )))?;
+            )),
+        )?;
 
         let mut contract_a = self.get_contract(FACTORY_NAME)?;
 
@@ -356,9 +352,7 @@ impl TestContext {
 
         neutron
             .contract_addrs
-            .entry(FACTORY_NAME.to_owned())
-            .or_default()
-            .push(contract.address);
+            .insert(FACTORY_NAME.to_owned(), contract.address);
 
         Ok(())
     }
@@ -383,10 +377,7 @@ impl TestContext {
         denom_b: impl Into<String>,
     ) -> Result<(), Error> {
         // Factory contract instance
-        let contracts = self.get_astroport_factory()?;
-        let contract_a = contracts
-            .first()
-            .ok_or(Error::MissingContextVariable(String::from(FACTORY_NAME)))?;
+        let contract_a = self.get_astroport_factory()?;
 
         // Create the pair
         let tx = contract_a.execute(

--- a/src/utils/setup/valence.rs
+++ b/src/utils/setup/valence.rs
@@ -437,9 +437,7 @@ impl TestContext {
 
         chain
             .contract_addrs
-            .entry(AUCTIONS_MANAGER_CONTRACT_NAME.to_owned())
-            .or_default()
-            .push(contract.address);
+            .insert(AUCTIONS_MANAGER_CONTRACT_NAME.to_owned(), contract.address);
 
         Ok(())
     }
@@ -488,9 +486,7 @@ impl TestContext {
 
         chain
             .contract_addrs
-            .entry(PRICE_ORACLE_NAME.to_owned())
-            .or_default()
-            .push(contract.address);
+            .insert(PRICE_ORACLE_NAME.to_owned(), contract.address);
 
         Ok(())
     }
@@ -637,13 +633,13 @@ impl TestContext {
         // The auctions manager for this deployment
         let contract_a = self.get_auctions_manager()?;
         let neutron = self.get_chain(NEUTRON_CHAIN_NAME);
-        let oracle = neutron
-            .contract_addrs
-            .get(PRICE_ORACLE_NAME)
-            .and_then(|addrs| addrs.first())
-            .ok_or(Error::MissingContextVariable(String::from(
-                "contract_addrs::price_oracle",
-            )))?;
+        let oracle =
+            neutron
+                .contract_addrs
+                .get(PRICE_ORACLE_NAME)
+                .ok_or(Error::MissingContextVariable(String::from(
+                    "contract_addrs::price_oracle",
+                )))?;
 
         let receipt = contract_a.execute(
             sender_key,

--- a/src/utils/test_context.rs
+++ b/src/utils/test_context.rs
@@ -364,7 +364,7 @@ pub struct LocalChain {
     pub admin_addr: String,
     pub native_denom: String,
     /// contract addresses for deployed instances of contracts
-    pub contract_addrs: HashMap<String, Vec<String>>,
+    pub contract_addrs: HashMap<String, String>,
     /// The name of the chain
     pub chain_name: String,
     pub chain_prefix: String,

--- a/src/utils/test_context.rs
+++ b/src/utils/test_context.rs
@@ -363,7 +363,7 @@ pub struct LocalChain {
     pub connection_ids: HashMap<String, String>,
     pub admin_addr: String,
     pub native_denom: String,
-    /// contract addresses for deployed instances of contracts
+    /// contract address for the deployed instance of a contract
     pub contract_addrs: HashMap<String, String>,
     /// The name of the chain
     pub chain_name: String,


### PR DESCRIPTION
Currently, the test context has a `contract_addrs` field, which stores deployed contract addresses for contracts by their name. However, the type of the field is `HashMap<String, Vec<String>>`, allowing it to store multiple instantiations of a single contract. This could be considered a footgun, as localic-utils always takes the first result of this vec anyway, meaning, if a contract is created twice, only the first version will be considered in any operations using `contract_addrs`.

This PR makes `contract_addrs` entries store only a single address, thus allowing use cases such as:
- Multiple tests with the same `TestContext`, but "clean" astroport factories, for example