### PR TITLE
Add support for logs file detection in test_context.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,3 +65,7 @@ pub const DEFAULT_AUCTION_LABEL: &str = "auction";
 
 pub const TX_HASH_QUERY_RETRIES: u16 = 5;
 pub const TX_HASH_QUERY_PAUSE_SEC: u64 = 2;
+
+/// Contains information about ibc paths, time started
+/// Used for cache invalidation purposes
+pub const LOGS_FILE_PATH: &str = "configs/logs.json";

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -12,6 +12,51 @@ use super::super::{
 use derive_builder::Builder;
 use serde::Deserialize;
 
+/// Struct representing the contents of config/logs.json
+#[derive(Deserialize)]
+pub struct Logs {
+    pub start_time: u64,
+    pub chains: Vec<LogsChainEntry>,
+    pub ibc_channels: Vec<LogsChannelEntry>,
+}
+
+/// Represents a chain entry in the logs file
+#[derive(Deserialize)]
+pub struct LogsChainEntry {
+    pub chain_id: String,
+    pub chain_name: String,
+    pub rpc_address: String,
+    pub grpc_address: String,
+    pub p2p_address: String,
+    pub ibc_paths: Vec<String>,
+}
+
+/// Represents an IBC channel entry in the logs file
+#[derive(Deserialize)]
+pub struct LogsChannelEntry {
+    pub chain_id: String,
+    pub channel: LogsChannel,
+}
+
+/// Represents the channel info in a channel entry
+#[derive(Deserialize)]
+pub struct LogsChannel {
+    pub state: String,
+    pub ordering: String,
+    pub counterparty: LogsCounterparty,
+    pub connection_hops: Vec<String>,
+    pub version: String,
+    pub port_id: String,
+    pub channel_id: String,
+}
+
+/// Represents counterparty info in a channel entry
+#[derive(Deserialize)]
+pub struct LogsCounterparty {
+    pub port_id: String,
+    pub channel_id: String,
+}
+
 #[derive(Deserialize, Default, Builder, Debug)]
 #[builder(setter(into, prefix = "with"))]
 pub struct ChainsVec {

--- a/src/utils/test_context.rs
+++ b/src/utils/test_context.rs
@@ -1,7 +1,11 @@
 use super::super::{
     error::Error,
-    types::{config::ConfigChain, contract::DeployedContractInfo, ibc::Channel as QueryChannel},
-    LOCAL_IC_API_URL, NEUTRON_CHAIN_NAME, TRANSFER_PORT,
+    types::{
+        config::{ConfigChain, Logs},
+        contract::DeployedContractInfo,
+        ibc::Channel as QueryChannel,
+    },
+    LOCAL_IC_API_URL, LOGS_FILE_PATH, NEUTRON_CHAIN_NAME, TRANSFER_PORT,
 };
 
 use localic_std::{
@@ -11,7 +15,7 @@ use localic_std::{
     transactions::ChainRequestBuilder,
 };
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fs::OpenOptions, path::PathBuf};
 
 /// A configurable builder that can be used to create a TestContext.
 pub struct TestContextBuilder {
@@ -313,6 +317,9 @@ impl TestContextBuilder {
             );
         }
 
+        let log_f = OpenOptions::new().read(true).open(LOGS_FILE_PATH).unwrap();
+        let log_file: Logs = serde_json::from_reader(&log_f).unwrap();
+
         Ok(TestContext {
             chains,
             transfer_channel_ids,
@@ -326,6 +333,7 @@ impl TestContextBuilder {
             astroport_token_registry: None,
             astroport_factory: None,
             unwrap_logs: *unwrap_raw_logs,
+            log_file,
         })
     }
 }
@@ -353,6 +361,9 @@ pub struct TestContext {
 
     /// Whether or not logs should be expected and guarded for each tx
     pub unwrap_logs: bool,
+
+    /// chains/logs.json
+    pub log_file: Logs,
 }
 
 pub struct LocalChain {


### PR DESCRIPTION
This PR adds support for detecting and loading the logs.json file into the TestContext.

## Overview of Changes
- Add types for deserializing `logs.json` to `types/config.rs`
- Load `logs.json` when finalizing `TestContextBuilder`
- Add `LOGS_FILE_PATH` to `lib.rs`