### PR TITLE
Implement Cache Auto Invalidation

### DIFF
--- a/examples/neutron.rs
+++ b/examples/neutron.rs
@@ -1,10 +1,13 @@
 use cosmwasm_std::Decimal;
 use localic_utils::{
     types::contract::MinAmount, ConfigChainBuilder, TestContextBuilder, DEFAULT_KEY,
+    NEUTRON_CHAIN_NAME,
 };
 use std::error::Error;
 
+const ARTIFACTS_DIR: &str = "contracts";
 const ACC_0_ADDR: &str = "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky";
+const LOCAL_CODE_ID_CACHE_PATH: &str = "code_id_cache.json";
 
 /// Demonstrates using localic-utils for neutron.
 fn main() -> Result<(), Box<dyn Error>> {
@@ -14,12 +17,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut ctx = TestContextBuilder::default()
         .with_unwrap_raw_logs(true)
         .with_api_url("http://localhost:42069/")
-        .with_artifacts_dir("contracts")
+        .with_artifacts_dir(ARTIFACTS_DIR)
         .with_chain(ConfigChainBuilder::default_neutron().build()?)
         .build()?;
 
     // Upload contracts
-    ctx.build_tx_upload_contracts().send()?;
+    ctx.build_tx_upload_contracts().send_with_local_cache(
+        "contracts",
+        NEUTRON_CHAIN_NAME,
+        LOCAL_CODE_ID_CACHE_PATH,
+    )?;
 
     // Create a token in the tokenfactory
     ctx.build_tx_create_tokenfactory_token()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,3 +65,7 @@ pub const DEFAULT_AUCTION_LABEL: &str = "auction";
 
 pub const TX_HASH_QUERY_RETRIES: u16 = 5;
 pub const TX_HASH_QUERY_PAUSE_SEC: u64 = 2;
+
+/// Contains information about ibc paths, time started
+/// Used for cache invalidation purposes
+pub const LOGS_FILE_PATH: &str = "configs/logs.json";

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -12,6 +12,51 @@ use super::super::{
 use derive_builder::Builder;
 use serde::Deserialize;
 
+/// Struct representing the contents of config/logs.json
+#[derive(Deserialize)]
+pub struct Logs {
+    pub start_time: u64,
+    pub chains: Vec<LogsChainEntry>,
+    pub ibc_channels: Vec<LogsChannelEntry>,
+}
+
+/// Represents a chain entry in the logs file
+#[derive(Deserialize)]
+pub struct LogsChainEntry {
+    pub chain_id: String,
+    pub chain_name: String,
+    pub rpc_address: String,
+    pub grpc_address: String,
+    pub p2p_address: String,
+    pub ibc_paths: Vec<String>,
+}
+
+/// Represents an IBC channel entry in the logs file
+#[derive(Deserialize)]
+pub struct LogsChannelEntry {
+    pub chain_id: String,
+    pub channel: LogsChannel,
+}
+
+/// Represents the channel info in a channel entry
+#[derive(Deserialize)]
+pub struct LogsChannel {
+    pub state: String,
+    pub ordering: String,
+    pub counterparty: LogsCounterparty,
+    pub connection_hops: Vec<String>,
+    pub version: String,
+    pub port_id: String,
+    pub channel_id: String,
+}
+
+/// Represents counterparty info in a channel entry
+#[derive(Deserialize)]
+pub struct LogsCounterparty {
+    pub port_id: String,
+    pub channel_id: String,
+}
+
 #[derive(Deserialize, Default, Builder, Debug)]
 #[builder(setter(into, prefix = "with"))]
 pub struct ChainsVec {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -110,7 +110,8 @@ impl TestContext {
         }
 
         let local_ic_session = self.log_file.start_time;
-        let session_cache_path = format!("{local_cache_path}_{local_ic_session}");
+        let session_cache_path =
+            local_cache_path.replace(".json", &format!("_{local_ic_session}.json"));
 
         // Use a local cache to avoid storing the same contract multiple times, useful for local testing
         let mut content = String::new();

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -109,9 +109,12 @@ impl TestContext {
             dir_entries.push(dir.unwrap());
         }
 
+        let local_ic_session = self.log_file.start_time;
+        let session_cache_path = format!("{local_cache_path}_{local_ic_session}");
+
         // Use a local cache to avoid storing the same contract multiple times, useful for local testing
         let mut content = String::new();
-        let cache: HashMap<String, u64> = match File::open(local_cache_path) {
+        let cache: HashMap<String, u64> = match File::open(&session_cache_path) {
             Ok(mut file) => {
                 if let Err(err) = file.read_to_string(&mut content) {
                     error!("Failed to read cache file: {}", err);
@@ -155,7 +158,7 @@ impl TestContext {
         }
 
         let contract_codes = serde_json::to_string(&local_chain.contract_codes).unwrap();
-        let mut file = File::create(local_cache_path).unwrap();
+        let mut file = File::create(session_cache_path).unwrap();
         file.write_all(contract_codes.as_bytes()).unwrap();
 
         Ok(())

--- a/src/utils/test_context.rs
+++ b/src/utils/test_context.rs
@@ -1,7 +1,11 @@
 use super::super::{
     error::Error,
-    types::{config::ConfigChain, contract::DeployedContractInfo, ibc::Channel as QueryChannel},
-    LOCAL_IC_API_URL, NEUTRON_CHAIN_NAME, TRANSFER_PORT,
+    types::{
+        config::{ConfigChain, Logs},
+        contract::DeployedContractInfo,
+        ibc::Channel as QueryChannel,
+    },
+    LOCAL_IC_API_URL, LOGS_FILE_PATH, NEUTRON_CHAIN_NAME, TRANSFER_PORT,
 };
 
 use localic_std::{
@@ -11,7 +15,7 @@ use localic_std::{
     transactions::ChainRequestBuilder,
 };
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fs::OpenOptions, path::PathBuf};
 
 /// A configurable builder that can be used to create a TestContext.
 pub struct TestContextBuilder {
@@ -313,6 +317,9 @@ impl TestContextBuilder {
             );
         }
 
+        let log_f = OpenOptions::new().read(true).open(LOGS_FILE_PATH).unwrap();
+        let log_file: Logs = serde_json::from_reader(&log_f).unwrap();
+
         Ok(TestContext {
             chains,
             transfer_channel_ids,
@@ -326,6 +333,7 @@ impl TestContextBuilder {
             astroport_token_registry: None,
             astroport_factory: None,
             unwrap_logs: *unwrap_raw_logs,
+            log_file,
         })
     }
 }
@@ -353,6 +361,9 @@ pub struct TestContext {
 
     /// Whether or not logs should be expected and guarded for each tx
     pub unwrap_logs: bool,
+
+    /// chains/logs.json
+    pub log_file: Logs,
 }
 
 pub struct LocalChain {


### PR DESCRIPTION
This PR implement automatic cache invalidation upon each restart of local-ic. This is achieved by appending the start time from logs.json to the cache path specified by the user. This should not change the external API.