### PR TITLE
Differentiate all contract deployments by chain

### DIFF
--- a/src/utils/queries.rs
+++ b/src/utils/queries.rs
@@ -5,9 +5,9 @@ use crate::{
 
 use super::{
     super::{
-        error::Error, AUCTION_CONTRACT_NAME, FACTORY_NAME, NEUTRON_CHAIN_NAME, OSMOSIS_CHAIN_NAME,
-        PAIR_NAME, PRICE_ORACLE_NAME, STABLE_PAIR_NAME, TX_HASH_QUERY_PAUSE_SEC,
-        TX_HASH_QUERY_RETRIES,
+        error::Error, AUCTIONS_MANAGER_CONTRACT_NAME, AUCTION_CONTRACT_NAME, FACTORY_NAME,
+        NEUTRON_CHAIN_NAME, OSMOSIS_CHAIN_NAME, PAIR_NAME, PRICE_ORACLE_NAME, STABLE_PAIR_NAME,
+        TX_HASH_QUERY_PAUSE_SEC, TX_HASH_QUERY_RETRIES,
     },
     test_context::TestContext,
 };
@@ -84,18 +84,20 @@ impl TestContext {
     pub fn get_auctions_manager(&self) -> Result<CosmWasm, Error> {
         let neutron = self.get_chain(NEUTRON_CHAIN_NAME);
 
-        let contract_info = self
-            .auctions_manager
-            .as_ref()
-            .ok_or(Error::MissingContextVariable(String::from(
-                "auctions_manager",
-            )))?;
+        let contract_addr = neutron
+            .contract_addrs
+            .get(AUCTIONS_MANAGER_CONTRACT_NAME)
+            .unwrap();
+        let code_id = neutron
+            .contract_codes
+            .get(AUCTIONS_MANAGER_CONTRACT_NAME)
+            .unwrap();
 
         Ok(CosmWasm::new_from_existing(
             &neutron.rb,
-            Some(contract_info.artifact_path.clone()),
-            Some(contract_info.code_id),
-            Some(contract_info.address.clone()),
+            None,
+            Some(*code_id),
+            Some(contract_addr.clone()),
         ))
     }
 

--- a/src/utils/setup/astroport.rs
+++ b/src/utils/setup/astroport.rs
@@ -1,8 +1,7 @@
 use super::super::{
     super::{
-        error::Error, types::contract::DeployedContractInfo, DEFAULT_KEY, FACTORY_NAME,
-        NEUTRON_CHAIN_ADMIN_ADDR, NEUTRON_CHAIN_NAME, PAIR_NAME, STABLE_PAIR_NAME, TOKEN_NAME,
-        TOKEN_REGISTRY_NAME, WHITELIST_NAME,
+        error::Error, DEFAULT_KEY, FACTORY_NAME, NEUTRON_CHAIN_ADMIN_ADDR, NEUTRON_CHAIN_NAME,
+        PAIR_NAME, STABLE_PAIR_NAME, TOKEN_NAME, TOKEN_REGISTRY_NAME, WHITELIST_NAME,
     },
     test_context::TestContext,
 };
@@ -218,11 +217,6 @@ impl TestContext {
         owner_addr: impl Into<String>,
     ) -> Result<(), Error> {
         let mut contract_a = self.get_contract(TOKEN_REGISTRY_NAME)?;
-        let code_id = contract_a
-            .code_id
-            .ok_or(Error::MissingContextVariable(String::from(
-                "astroport_token_registry::code_id",
-            )))?;
 
         let contract = contract_a.instantiate(
             key,
@@ -235,24 +229,12 @@ impl TestContext {
             "--gas 1000000",
         )?;
         let addr = contract.address;
-        let artifact_path =
-            contract_a
-                .file_path
-                .ok_or(Error::MissingContextVariable(String::from(
-                    "astroport_token_registry::artifact_path",
-                )))?;
 
         let neutron = self.get_mut_chain(NEUTRON_CHAIN_NAME);
 
         neutron
             .contract_addrs
             .insert(TOKEN_REGISTRY_NAME.to_owned(), addr.clone());
-
-        self.astroport_token_registry = Some(DeployedContractInfo {
-            code_id,
-            address: addr,
-            artifact_path,
-        });
 
         Ok(())
     }

--- a/src/utils/setup/valence.rs
+++ b/src/utils/setup/valence.rs
@@ -1,10 +1,7 @@
 use super::super::{
     super::{
         error::Error,
-        types::contract::{
-            AuctionStrategy, ChainHaltConfig, DeployedContractInfo, MinAmount,
-            PriceFreshnessStrategy,
-        },
+        types::contract::{AuctionStrategy, ChainHaltConfig, MinAmount, PriceFreshnessStrategy},
         AUCTIONS_MANAGER_CONTRACT_NAME, AUCTION_CONTRACT_NAME, DEFAULT_AUCTION_LABEL, DEFAULT_KEY,
         NEUTRON_CHAIN_ADMIN_ADDR, NEUTRON_CHAIN_NAME, PRICE_ORACLE_NAME,
     },
@@ -422,16 +419,6 @@ impl TestContext {
             None,
             "",
         )?;
-
-        self.auctions_manager = Some(DeployedContractInfo {
-            code_id: contract_a.code_id.ok_or(Error::Misc(format!(
-                "contract '{AUCTIONS_MANAGER_CONTRACT_NAME}' has no code ID"
-            )))?,
-            address: contract.address.clone(),
-            artifact_path: contract_a.file_path.ok_or(Error::Misc(format!(
-                "contract '{AUCTIONS_MANAGER_CONTRACT_NAME}' has no file path"
-            )))?,
-        });
 
         let chain = self.get_mut_chain(NEUTRON_CHAIN_NAME);
 

--- a/src/utils/test_context.rs
+++ b/src/utils/test_context.rs
@@ -2,7 +2,6 @@ use super::super::{
     error::Error,
     types::{
         config::{ConfigChain, Logs},
-        contract::DeployedContractInfo,
         ibc::Channel as QueryChannel,
     },
     ICTEST_HOME_VAR, LOCAL_IC_API_URL, NEUTRON_CHAIN_NAME, TRANSFER_PORT,
@@ -353,9 +352,6 @@ impl TestContextBuilder {
             artifacts_dir: artifacts_dir
                 .clone()
                 .ok_or(Error::MissingBuilderParam(String::from("artifacts_dir")))?,
-            auctions_manager: None,
-            astroport_token_registry: None,
-            astroport_factory: None,
             unwrap_logs: *unwrap_raw_logs,
             log_file,
         })
@@ -375,13 +371,6 @@ pub struct TestContext {
     pub ibc_denoms: HashMap<(String, String), String>,
     /// The path to .wasm contract artifacts
     pub artifacts_dir: String,
-
-    /// Valence deployment info
-    pub auctions_manager: Option<DeployedContractInfo>,
-
-    /// Astroport deployment info
-    pub astroport_token_registry: Option<DeployedContractInfo>,
-    pub astroport_factory: Option<DeployedContractInfo>,
 
     /// Whether or not logs should be expected and guarded for each tx
     pub unwrap_logs: bool,


### PR DESCRIPTION
Closes #24 by removing singleton-style TestContext contract deployment info in favor of LocalChain-specific contract_addrs.